### PR TITLE
Add TTS engine: piper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log
 yarn-error.log
 package-lock.json
 ./build/
+/tmp/

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "llamaModelPath": "/home/kache/models/llama/nous-hermes-13b.ggmlv3.q4_1.bin",
   "whisperModelPath": "/home/kache/models/whisper/ggml-tiny.en.bin",
-  "audioListenerScript": "sample_audio.sh"
+  "audioListenerScript": "sample_audio.sh",
+  "piperModelPath": "~/models/piper/en-gb-southern_english_female-low.onnx"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "requires": true,
     "license": "MIT",
     "scripts": {
-        "start": "npx ts-node ./index.ts"
+        "start": "npx ts-node ./index.ts",
+        "test-voice": "npx ts-node ./tests/voice.test.ts"
     },
     "dependencies": {
         "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
         "start": "npx ts-node ./index.ts"
     },
     "dependencies": {
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@types/node": "^18.16.16",
+        "@types/uuid": "^9.0.2",
         "typescript": "^4.9.5"
     }
 }

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -1,0 +1,67 @@
+import { spawn, ChildProcessWithoutNullStreams, exec } from 'child_process';
+import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs';
+
+export const generateAudio = (text: string): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    const modelPath = '~/models/piper/en-gb-southern_english_female-low.onnx';
+    const fileName = uuidv4();
+    const directoryPath = './tmp';
+    const outputFilePath = `${directoryPath}/${fileName}.wav`;
+
+    // Check if the tmp directory exists, create it if it doesn't
+    if (!fs.existsSync(directoryPath)) {
+      try {
+        fs.mkdirSync(directoryPath, { recursive: true });
+      } catch (err) {
+        console.error('Failed to create directory:', err);
+        reject(err);
+        return;
+      }
+    }
+
+    exec(`echo "${text}" | piper --model ${modelPath} --output_file ${outputFilePath}`, (error) => {
+      if (error) {
+        console.error(`exec error: ${error}`);
+        reject(error);
+      } else {
+        console.log(`Audio file has been saved to ${outputFilePath}`);
+        resolve(fileName);
+      }
+    });
+  });
+};
+
+interface AudioPlayerState {
+  isPlaying: boolean;
+  process?: ChildProcessWithoutNullStreams;
+}
+
+const audioPlayerState: AudioPlayerState = {
+  isPlaying: false,
+  process: undefined,
+};
+
+export const playAudioFile = async (fileName: string): Promise<void> => {
+  if (audioPlayerState.isPlaying) {
+    stopAudioPlayback();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    audioPlayerState.isPlaying = true;
+    const audioPath = `./tmp/${fileName}.wav`;
+    audioPlayerState.process = spawn('ffplay', ['-nodisp', '-autoexit', audioPath]);
+    audioPlayerState.process.on('close', (code) => {
+      console.log(`ffplay exited with code ${code}`);
+      audioPlayerState.isPlaying = false;
+      resolve();
+    });
+  });
+};
+
+export const stopAudioPlayback = (): void => {
+  if (audioPlayerState.process) {
+    audioPlayerState.process.kill('SIGINT');
+    audioPlayerState.isPlaying = false;
+  }
+};

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -1,10 +1,12 @@
 import { spawn, ChildProcessWithoutNullStreams, exec } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
+import config from '../config.json';
 import fs from 'fs';
+const { piperModelPath } = config;
 
 export const generateAudio = (text: string): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
-    const modelPath = '~/models/piper/en-gb-southern_english_female-low.onnx';
+    const modelPath = piperModelPath;
     const fileName = uuidv4();
     const directoryPath = './tmp';
     const outputFilePath = `${directoryPath}/${fileName}.wav`;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+Actually, tests should just be scripts that you can run.
+
+To run these, npx ts-node ./tests/{test_name}

--- a/tests/voice.test.ts
+++ b/tests/voice.test.ts
@@ -1,0 +1,22 @@
+import {playAudioFile, stopAudioPlayback, generateAudio} from '../src/voice'
+
+async function main() {
+  const fileName = await generateAudio('Hello world, this is a longer demo. I am going to keep on talking and talking and talking');
+
+  // Start audio playback
+  playAudioFile(fileName);
+
+  // In the middle of playback, generate another audio file and play it
+  setTimeout(async () => {
+    const newFileName = await generateAudio('This is a new file. The previous one has been stopped. And this one will be stopped really, really, really, really soon.');
+    playAudioFile(newFileName);
+  }, 3000);
+
+  // Stop it
+  setTimeout(async () => {
+    stopAudioPlayback();
+  }, 9000);
+
+}
+
+main();


### PR DESCRIPTION
First diff going in for https://github.com/yacineMTB/talk/issues/3

https://github.com/yacineMTB/talk/assets/10282244/203804e4-4639-4078-a09a-00bb5d0289fd

Now, our model can speak!

Here's what the time looks like, as observed by the cpp
```
[kache@whitebox ~]$ echo "I need to renable the response reflex. Though, I think to start with, we can just use a simple keypress." | piper --model ~/models/piper/en-gb-southern_english_female-low.onnx
Load time: 0.157878 sec
WARNING: Piper was not compiled with pcaudiolib. Output audio will be written to the current directory.
Output directory: "/home/kache/."
/home/kache/./1686592663635066288.wav
Real-time factor: 0.0332105 (infer=0.172695 sec, audio=5.2 sec)
```
This gives us a really good lowerbound on time
It looks like *most* of the time being observed from the node proc (refer to video) is from resource acquisition.
We'll fix it later: https://github.com/yacineMTB/talk/issues/6