### PR TITLE
Update: build.sh; WIP

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,7 @@ else
 fi
 
 mkdir -p bindings
+mkdir -p bindings/whisper
 
 # Navigate to whisper.cpp examples directory and install dependencies
 echo "Installing npm dependencies for whisper.cpp examples..."
@@ -69,11 +70,11 @@ cp -r build/Release/* ../bindings/whisper/
 # Navigate back to the root directory
 cd ../
 
-# Navigate to llama.cpp 
+# Navigate to llama.cpp
 cd llama.cpp
 
 echo "Compiling llama.cpp server"
-LLAMA_BUILD_SERVER=1 make
+LLAMA_BUILD_SERVER=1 gmake
 
 # Navigate back to the root directory
 cd ../

--- a/build.sh
+++ b/build.sh
@@ -73,13 +73,14 @@ cd ../
 cd llama.cpp
 
 echo "Compiling llama.cpp server"
+rm -rf build-server
 mkdir build-server
 cd build-server
 cmake -DLLAMA_BUILD_SERVER=ON ..
 cmake --build . --config Release
 
 # Navigate back to the root directory
-cd ../
+cd ../../
 
 # Prompt the user for whether they want to download models or not
 read -p "Do you want to download models? [y/n] " DOWNLOAD_CHOICE

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,6 @@ else
     CUBLAS_FLAG_CMAKE="OFF"
 fi
 
-mkdir -p bindings
 mkdir -p bindings/whisper
 
 # Navigate to whisper.cpp examples directory and install dependencies
@@ -74,7 +73,10 @@ cd ../
 cd llama.cpp
 
 echo "Compiling llama.cpp server"
-LLAMA_BUILD_SERVER=1 gmake
+mkdir build-server
+cd build-server
+cmake -DLLAMA_BUILD_SERVER=ON ..
+cmake --build . --config Release
 
 # Navigate back to the root directory
 cd ../


### PR DESCRIPTION
This should make the `build.sh` script work. I've tested it on my local machine (i7 2020 MBP) and works. I will test it on my Ubuntu machine soon. 

Using `gmake` was the fix for macOS according to, ggerganov/llama.cpp#1570. I'm not sure if this will break for other platforms, in that case, we can add a simple detection depending on what platform the user is on.