### PR TITLE
dont use old cuts and update cut timestamp to not cut so aggressively

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -72,16 +72,22 @@ const getLastTranscriptionEvent = (): TranscriptionEvent => {
   const transcriptionEvents = eventlog.events.filter(e => e.eventType === 'transcription');
   return transcriptionEvents[transcriptionEvents.length - 1] as TranscriptionEvent;
 }
+
+const getLastResponseReflexTimestamp = (): number => {
+  const responseReflexEvents = eventlog.events.filter(e => e.eventType === 'responseReflex');
+  return responseReflexEvents.length > 0 ? responseReflexEvents[responseReflexEvents.length - 1].timestamp : eventlog.events[0].timestamp;
+};
+
 const getCutTimestamp = (): number => {
   const cutTranscriptionEvents = eventlog.events.filter(e => e.eventType === 'cutTranscription');
   const lastCut = cutTranscriptionEvents.length > 0 ? cutTranscriptionEvents[cutTranscriptionEvents.length - 1].data.lastAudioByteEventTimestamp : eventlog.events[0].timestamp;
-  const responseReflexEvents = eventlog.events.filter(e => e.eventType === 'responseReflex');
-  const lastResponseReflex = responseReflexEvents.length > 0 ? responseReflexEvents[responseReflexEvents.length - 1].timestamp : eventlog.events[0].timestamp;
+  const lastResponseReflex = getLastResponseReflexTimestamp();
   return Math.max(lastResponseReflex, lastCut);
-
 }
+
 const getTransciptionSoFar = (): string => {
-  const cutTranscriptionEvents = eventlog.events.filter(e => e.eventType === 'cutTranscription');
+  const lastResponseReflex = getLastResponseReflexTimestamp();
+  const cutTranscriptionEvents = eventlog.events.filter(e => e.eventType === 'cutTranscription' && e.timestamp > lastResponseReflex);
   const lastTranscriptionEvent = getLastTranscriptionEvent();
   const lastCutTranscriptionEvent = cutTranscriptionEvents[cutTranscriptionEvents.length - 1];
   let transcription = cutTranscriptionEvents.map(e => e.data.transcription).join(' ');
@@ -180,8 +186,7 @@ const transcriptionEventHandler = async (event: AudioBytesEvent) => {
 }
 
 const cutTranscriptionEventHandler = async (event: TranscriptionEvent) => {
-  const cutTranscriptionEvents = eventlog.events.filter(e => e.eventType === 'cutTranscription');
-  const lastCut = cutTranscriptionEvents.length > 0 ? cutTranscriptionEvents[cutTranscriptionEvents.length - 1].timestamp : eventlog.events[0].timestamp;
+  const lastCut = getCutTimestamp();
   const timeDiff = event.timestamp - lastCut;
   if (timeDiff > BUFFER_LENGTH_MS) {
     const cutTranscriptionEvent: CutTranscriptionEvent = {


### PR DESCRIPTION
## What this does
It's possible I'm crazy but I noticed that the cutTranscriptions were always being included despite no longer being relevant.

This does two things
1. Filters out cutTranscriptions before the most recent reflexResponse (as I believe they should no longer be included)
2. Uses the lastCut timestamp for making new cutTranscriptionEvents. It makes sense to me that the cutTranscription event uses the same buffer length as the transcription event.

Feel free to just close this if you don't think it's worth merging or if you've already changed this in some other branch.


### Notes
Thanks heaps for making this, I've been having fun playing with it.
I've never contributed to open source and have no idea what I'm doing.

I've made some other small changes in a branch to run this using ChatGPT to speak mandarin.
If you're open to other random PRs I might make one (though it's pretty shit atm).

