### PR TITLE
Include all audio before the response reflex

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ else
     CUBLAS_FLAG_CMAKE="OFF"
 fi
 
-mkdir -p bindings
+mkdir -p bindings/whisper
 
 # Navigate to whisper.cpp examples directory and install dependencies
 echo "Installing npm dependencies for whisper.cpp examples..."

--- a/index.ts
+++ b/index.ts
@@ -204,6 +204,9 @@ const transcriptionEventHandler = async (event: AudioBytesEvent) => {
         lastAudioByteEventTimestamp: audioBytesEvents[audioBytesEvents.length - 1].timestamp
       }
     }
+    if (responseMutex) {
+        responseReflexEventHandler();
+    }
     newEventHandler(transcriptionEvent);
     transcriptionMutex = false;
   }
@@ -226,8 +229,14 @@ const cutTranscriptionEventHandler = async (event: TranscriptionEvent) => {
   }
 }
 
+let responseMutex = false;
 const responseReflexEventHandler = async (): Promise<void> => {
   await globalWhisperPromise;
+  if (!responseMutex) {
+    responseMutex = true;
+    return;
+  }
+  responseMutex = false;
   const responseReflexEvent: ResponseReflexEvent = {
     timestamp: Number(Date.now()),
     eventType: 'responseReflex',


### PR DESCRIPTION
Right now, words spoken before the response reflex are being cut off due to buffering. I added a mutex that only allows the responseReflexEventHandler to fire after the next transcription.

One tradeoff here is that excess audio may be captured, but the user will usually be done speaking.

