### PR TITLE
Remove transcription artifacts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -164,7 +164,9 @@ const transcriptionEventHandler = async (event: AudioBytesEvent) => {
   if (!transcriptionMutex && joinedBuffer.length > ONE_SECOND) {
     transcriptionMutex = true;
     globalWhisperPromise = whisper.whisperInferenceOnBytes(joinedBuffer);
-    const transcription = await globalWhisperPromise;
+    const rawTranscription = await globalWhisperPromise;
+    // Remove transcription artifacts like (wind howling)
+    const transcription = rawTranscription.replace(/\s*\[[^\]]*\]\s*|\s*\([^)]*\)\s*/g, '');
     const transcriptionEvent: TranscriptionEvent = {
       timestamp: Number(Date.now()),
       eventType: 'transcription',


### PR DESCRIPTION
Noise can result in strange transcriptions, including: [MUSIC PLAYING] [gunshots] (screaming) (wind howling)

These are now removed immediately after whisper finishes, which minimizes the chunk size.