### PR TITLE
Add interrupt event

### DIFF
--- a/src/talk.ts
+++ b/src/talk.ts
@@ -1,15 +1,24 @@
 import { playAudioFile, generateAudio } from './depedenciesLibrary/voice'
-import { llamaInvoke } from './depedenciesLibrary/llm';
+import { llamaInvoke, LlamaStreamCommand } from './depedenciesLibrary/llm';
 
 // Talk: Greedily generate audio while completing an LLM inference
-export const talk = async (prompt: string, input: string, sentenceCallback: (sentence: string) => void): Promise<string> => {
+export const talk = async (prompt: string, input: string, interruptCallback: (token: string, streamId: string) => boolean, sentenceCallback: (sentence: string) => void): Promise<string|void> => {
   let sentenceEndRegex = /[.!?,;]/;  // Adjust as necessary.
   let promisesChain = Promise.resolve();
 
   const sentences: string[] = [];
   let currentSentence: string[] = [];
+  const streamId = Math.random().toString(36).substring(7);
 
-  const response = await llamaInvoke(prompt, input, (token: string) => {
+  const response = await llamaInvoke(prompt, input, (token: string): LlamaStreamCommand => {
+    const streamCommand: LlamaStreamCommand = {
+      stop: false
+    }
+    const stopStream = interruptCallback(token, streamId);
+    if (stopStream) {
+      streamCommand.stop = true;
+      return streamCommand;
+    }
     token = token.replace(/[^a-zA-Z0-9 .,!?'\n-]/g, '');
     currentSentence.push(token);
     // Check if the token ends a sentence.
@@ -17,13 +26,14 @@ export const talk = async (prompt: string, input: string, sentenceCallback: (sen
       const sentence = currentSentence.join('');
       sentences.push(sentence);
       const promise = generateAudio(sentence);
-      promisesChain = promisesChain.then(async () => { 
+      promisesChain = promisesChain.then(async () => {
         await promise.then(playAudioFile);
         sentenceCallback(sentence);
       });
       sentenceEndRegex = /[.!?]/;
       currentSentence = [];
     }
+    return streamCommand;
   });
   await promisesChain;
   return response;


### PR DESCRIPTION
If the user talks above a threshold while the LLM is talking, interrupt the LLM.

A stream ID is used to track which promise chain should be silenced.

This depends on a patch to llama.cpp, which adds an /interrupt endpoint to the example server.