### PR TITLE
Add interrupt event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ const BIT_DEPTH = 16;
 const ONE_SECOND = SAMPLING_RATE * (BIT_DEPTH / 8) * CHANNELS;
 const BUFFER_LENGTH_SECONDS = 28;
 const BUFFER_LENGTH_MS = BUFFER_LENGTH_SECONDS * 1000;
+const INTERRUPTION_LENGTH_CHARS = 20;
 const DEFAULT_LLAMA_SERVER_URL = 'http://127.0.0.1:8080'
 
 let llamaServerUrl: string = DEFAULT_LLAMA_SERVER_URL;
@@ -39,9 +40,8 @@ if ('personaFile' in config) {
   }
 }
 
-
 // INTERFACES
-type EventType = 'audioBytes' | 'responseReflex' | 'transcription' | 'cutTranscription' | 'talk';
+type EventType = 'audioBytes' | 'responseReflex' | 'transcription' | 'cutTranscription' | 'talk' | 'interrupt';
 interface Event {
   eventType: EventType;
   timestamp: number;
@@ -79,6 +79,12 @@ interface TalkEvent extends Event {
   eventType: 'talk';
   data: {
     response: string;
+  }
+}
+interface InterruptEvent extends Event {
+  eventType: 'interrupt';
+  data: {
+    streamId: string;
   }
 }
 interface EventLog {
@@ -147,7 +153,7 @@ const getDialogue = (): string => {
 }
 
 // const updateScreenEvents: Set<EventType> = new Set([])
-const updateScreenEvents: Set<EventType> = new Set(['responseReflex', 'cutTranscription', 'talk'])
+const updateScreenEvents: Set<EventType> = new Set(['responseReflex', 'cutTranscription', 'talk', 'interrupt'])
 const updateScreen = (event: Event) => {
   if (updateScreenEvents.has(event.eventType)) {
     console.log(getDialogue())
@@ -239,6 +245,29 @@ const responseReflexEventHandler = async (): Promise<void> => {
 }
 
 const talkEventHandler = (event: ResponseReflexEvent): void => {
+  // Check if stream has been interrupted by the user
+  const interruptCallback = (token: string, streamId: string): boolean => {
+    const streamInterrupts = eventlog.events.filter(e => e.eventType === 'interrupt' && (e.data?.streamId == streamId));
+    if (streamInterrupts?.length) {
+      return true;
+    }
+    const lastTranscription = getLastTranscriptionEvent();
+    const lastTranscriptionLength = lastTranscription?.data?.transcription?.length;
+    const lastTranscriptionTimestamp = lastTranscription?.timestamp;
+    const lastResponseReflexTimestamp = getLastResponseReflexTimestamp();
+    if ((lastTranscriptionLength > 0) && (lastTranscriptionTimestamp > lastResponseReflexTimestamp) && (lastTranscriptionLength >= INTERRUPTION_LENGTH_CHARS)) {
+      const interruptEvent: InterruptEvent = {
+        timestamp: Number(Date.now()),
+        eventType: 'interrupt',
+        data: {
+          streamId
+        }
+      }
+      newEventHandler(interruptEvent);
+      return true;
+    }
+    return false;
+  }
   const talkCallback = (sentence: string) => {
     const talkEvent: TalkEvent = {
       timestamp: Number(Date.now()),
@@ -255,6 +284,7 @@ const talkEventHandler = (event: ResponseReflexEvent): void => {
     input,
     llamaServerUrl,
     personaConfig,
+    interruptCallback,
     talkCallback
   );
 }
@@ -276,6 +306,7 @@ const eventDag: { [key in EventType]: { [key in EventType]?: (event: any) => voi
   },
   cutTranscription: {},
   talk: {},
+  interrupt: {}
 }
 
 const audioProcess = spawn('bash', [audioListenerScript]);

--- a/src/talk.ts
+++ b/src/talk.ts
@@ -1,15 +1,24 @@
 import { playAudioFile, generateAudio } from './depedenciesLibrary/voice'
-import { llamaInvoke } from './depedenciesLibrary/llm';
+import { llamaInvoke, LlamaStreamCommand } from './depedenciesLibrary/llm';
 
 // Talk: Greedily generate audio while completing an LLM inference
-export const talk = async (prompt: string, input: string, llamaServerUrl: string, personaConfig:string, sentenceCallback: (sentence: string) => void): Promise<string> => {
+export const talk = async (prompt: string, input: string, llamaServerUrl: string, personaConfig:string, interruptCallback: (token: string, streamId: string) => boolean, sentenceCallback: (sentence: string) => void): Promise<string> => {
   let sentenceEndRegex = /[.!?,;]/;  // Adjust as necessary.
   let promisesChain = Promise.resolve();
 
   const sentences: string[] = [];
   let currentSentence: string[] = [];
+  const streamId = Math.random().toString(36).substring(7);
 
-  const response = await llamaInvoke(prompt, input, llamaServerUrl, personaConfig, (token: string) => {
+  const response = await llamaInvoke(prompt, input, llamaServerUrl, personaConfig, (token: string): LlamaStreamCommand => {
+    const streamCommand: LlamaStreamCommand = {
+      stop: false
+    }
+    const stopStream = interruptCallback(token, streamId);
+    if (stopStream) {
+      streamCommand.stop = true;
+      return streamCommand;
+    }
     token = token.replace(/[^a-zA-Z0-9 .,!?'\n-]/g, '');
     currentSentence.push(token);
     // Check if the token ends a sentence.
@@ -17,13 +26,14 @@ export const talk = async (prompt: string, input: string, llamaServerUrl: string
       const sentence = currentSentence.join('');
       sentences.push(sentence);
       const promise = generateAudio(sentence);
-      promisesChain = promisesChain.then(async () => { 
+      promisesChain = promisesChain.then(async () => {
         await promise.then(playAudioFile);
         sentenceCallback(sentence);
       });
       sentenceEndRegex = /[.!?]/;
       currentSentence = [];
     }
+    return streamCommand;
   });
   await promisesChain;
   return response;


### PR DESCRIPTION
If the user talks above a threshold while the LLM is talking, interrupt the LLM.

A stream ID is used to track which promise chain should be silenced.

This depends on a patch to llama.cpp, which adds an /interrupt endpoint to the example server.